### PR TITLE
passing imageURL value from service to Avatar to set icon

### DIFF
--- a/src/components/Results/Ndex/NetworkList.jsx
+++ b/src/components/Results/Ndex/NetworkList.jsx
@@ -125,7 +125,8 @@ const NetworkList = props => {
       networkUUID,
       percentOverlap,
       nodes,
-      edges
+      edges,
+      imageURL
     } = networkEntry
 
     return (
@@ -136,7 +137,7 @@ const NetworkList = props => {
         onClick={val => handleFetch(networkUUID, description, nodes, edges)}
       >
         <ListItemAvatar>
-          <Avatar className={classes.networkAvatar}>N</Avatar>
+          <Avatar className={classes.networkAvatar} src={imageURL}>N</Avatar>
         </ListItemAvatar>
         <ListItemText
           className={classes.menuText}


### PR DESCRIPTION
For each result there is a new field `imageURL` that contains url to image or null. This pull request has an untested hack to set the image in the Avator. A version of the service offering this new field is on port 8090 of secret