### PR TITLE
Issues/2

### DIFF
--- a/src/actions/cyrest.js
+++ b/src/actions/cyrest.js
@@ -7,3 +7,9 @@ export const IMPORT_NETWORK_FAILED = 'IMPORT_NETWORK_FAILED'
 export const importNetworkStarted = createAction(IMPORT_NETWORK_STARTED)
 export const importNetworkSucceeded = createAction(IMPORT_NETWORK_SUCCEEDED)
 export const importNetworkFailed = createAction(IMPORT_NETWORK_FAILED)
+
+export const SET_PORT = 'SET_PORT'
+export const setPort = createAction(SET_PORT)
+
+export const SET_AVAILABLE = 'SET_AVAILABLE'
+export const setAvailable = createAction(SET_AVAILABLE)

--- a/src/actions/uiState.js
+++ b/src/actions/uiState.js
@@ -14,3 +14,6 @@ export const setCytoscapeStatus = createAction(SET_CYTOSCAPE_STATUS)
 
 export const SET_SERVICES_LIST_OPEN = 'SET_SERVICES_LIST_OPEN'
 export const setServicesListOpen = createAction(SET_SERVICES_LIST_OPEN)
+
+export const SET_HIGHLIGHTS = 'SET_HIGHLIGHTS'
+export const setHighlights = createAction(SET_HIGHLIGHTS)

--- a/src/components/AppShell/index.jsx
+++ b/src/components/AppShell/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import './style.css'
 import TitleBar from './TitleBar'
 import SettingsPanel from '../SettingsPanel'
@@ -38,6 +38,14 @@ const styles = theme => ({
 })
 
 const AppShell = props => {
+  useEffect(() => {
+    const urlParams = new URLSearchParams(props.history.location.search)
+    const cyrestport = urlParams.get('cyrestport')
+    if (cyrestport) {
+      props.cyrestActions.setPort(cyrestport)
+    }
+    return () => {}
+  }, [])
   const { classes, ...others } = props
 
   const open = props.uiState.isSettingsOpen

--- a/src/components/HomePanel/index.jsx
+++ b/src/components/HomePanel/index.jsx
@@ -8,8 +8,6 @@ import LoadingPanel from '../LoadingPanel'
 
 const HomePanel = props => {
   useEffect(() => {
-    // Call search
-
     if (props.search.results !== null) {
       const jobId = props.search.results.jobId
       props.searchActions.fetchResultStarted({ jobId })

--- a/src/components/Results/Ndex/Highlighter.jsx
+++ b/src/components/Results/Ndex/Highlighter.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import FormGroup from '@material-ui/core/FormGroup'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import Switch from '@material-ui/core/Switch'
+
+const Highlighter = props => {
+  const highlights = props.uiState.highlights
+  const handleChange = (evt, checked) => {
+    props.uiStateActions.setHighlights(checked)
+  }
+
+  return (
+    <FormGroup row>
+      <FormControlLabel
+        control={<Switch checked={highlights} onChange={handleChange} />}
+        label="Highlight query genes"
+      />
+    </FormGroup>
+  )
+}
+
+export default Highlighter

--- a/src/components/Results/Ndex/NetworkList.jsx
+++ b/src/components/Results/Ndex/NetworkList.jsx
@@ -82,86 +82,7 @@ const handleErrors = res => {
 }
 
 const NetworkList = props => {
-  const { classes, hits, sourceUUID } = props
-
-  const geneList = props.search.queryList
-
-  const id = props.search.results.jobId
-
-  const handleFetch = (networkUUID, networkName, nodeCount, edgeCount) => {
-    props.networkActions.setNetworkSize({
-      nodeCount,
-      edgeCount
-    })
-
-    const networkSize = nodeCount + edgeCount
-
-    // Do not load if size is too big to render!
-    if (networkSize > NETWORK_SIZE_TH) {
-      return
-    }
-
-    checkCytoscapeConnection(props)
-    props.networkActions.networkFetchStarted({
-      id,
-      sourceUUID,
-      networkUUID,
-      networkName,
-      geneList
-    })
-  }
-
-  const getListItem = (networkEntry, classes) => {
-    const {
-      description,
-      networkUUID,
-      percentOverlap,
-      nodes,
-      edges,
-      imageURL
-    } = networkEntry
-
-    return (
-      <MenuItem
-        className={classes.menuItem}
-        alignItems="flex-start"
-        key={networkUUID}
-        onClick={val => handleFetch(networkUUID, description, nodes, edges)}
-      >
-        <ListItemAvatar>
-          <Avatar className={classes.networkAvatar} src={imageURL} />
-        </ListItemAvatar>
-        <ListItemText
-          className={classes.menuText}
-          primary={description}
-          secondary={
-            <React.Fragment>
-              <Typography
-                component="span"
-                className={classes.inline}
-                color="textPrimary"
-              >
-                {'Nodes: ' + nodes + ', Edges: ' + edges}
-              </Typography>
-            </React.Fragment>
-          }
-        />
-
-        <ListItemSecondaryAction className={classes.secondary}>
-          <div
-            style={{
-              background: 'teal',
-              color: 'white',
-              height: '1.5em',
-              width: percentOverlap * 3 + 'px'
-            }}
-          >
-            <Typography variant="body2" style={{color: '#AAAAAA'}}>{percentOverlap + '%'}</Typography>
-          </div>
-        </ListItemSecondaryAction>
-      </MenuItem>
-    )
-  }
+  const { classes, hits, renderNetworkListItem, network } = props
 
   if (!hits) {
     return <div className="network-list-wrapper" />
@@ -170,8 +91,11 @@ const NetworkList = props => {
   return (
     <div className="network-list-wrapper">
       <Sorter />
+
       <div className="network-list">
-        <MenuList>{hits.map(entry => getListItem(entry, classes))}</MenuList>
+        <MenuList>
+          {hits.map(entry => renderNetworkListItem(entry, classes))}
+        </MenuList>
       </div>
     </div>
   )

--- a/src/components/Results/Ndex/NetworkToolbar.jsx
+++ b/src/components/Results/Ndex/NetworkToolbar.jsx
@@ -8,6 +8,7 @@ import { fade } from '@material-ui/core/styles/colorManipulator'
 import { withStyles } from '@material-ui/core/styles'
 import MenuIcon from '@material-ui/icons/Menu'
 import OpenInButton from './OpenInButton'
+import Highlighter from './Highlighter'
 
 const styles = theme => ({
   toolbar: {
@@ -98,6 +99,7 @@ const NetworkToolbar = props => {
         {props.network.networkName}
       </Typography>
       <div className={classes.grow} />
+      <Highlighter {...others} />
       <OpenInButton {...others} />
     </div>
   )

--- a/src/components/Results/Ndex/NetworkView.jsx
+++ b/src/components/Results/Ndex/NetworkView.jsx
@@ -19,7 +19,6 @@ const NetworkView = props => {
   const [resized, setResize] = useState(null)
 
   const handleResizeEnd = e => {
-    console.log('+++++++!!!!! resizeE', e)
     setResize(e)
   }
 

--- a/src/components/Results/Ndex/OpenInButton.jsx
+++ b/src/components/Results/Ndex/OpenInButton.jsx
@@ -12,18 +12,14 @@ const styles = theme => ({
   }
 })
 
-const OpenInButton = props => {
-  const { classes, uiState, network } = props
-
-  const handleImportNetwork = () => {
-    props.cyrestActions.importNetworkStarted(network.originalCX)
-  }
+const OpenInButton = (props) => {
+  const { classes, cyrest, handleImportNetwork } = props
 
   return (
     <Button
       variant="contained"
       color="default"
-      disabled={!uiState.isCytoscapeRunning}
+      disabled={!cyrest.available}
       onClick={handleImportNetwork}
     >
       Open in

--- a/src/components/Results/Ndex/index.jsx
+++ b/src/components/Results/Ndex/index.jsx
@@ -5,6 +5,19 @@ import Split from 'react-split'
 import NetworkView from './NetworkView'
 import NetworkList from './NetworkList'
 
+import ListItemText from '@material-ui/core/ListItemText'
+import ListItemAvatar from '@material-ui/core/ListItemAvatar'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+
+import Avatar from '@material-ui/core/Avatar'
+import Typography from '@material-ui/core/Typography'
+
+import MenuItem from '@material-ui/core/MenuItem'
+
+import * as cyRESTApi from '../../../api/cyrest'
+
+const NETWORK_SIZE_TH = 5000
+
 /**
  * Top page for the application
  *
@@ -12,11 +25,123 @@ import NetworkList from './NetworkList'
  * @returns {*}
  * @constructor
  */
-const Ndex = props => (
-  <Split sizes={[50, 50]} gutterSize={7} className="ndex-base">
-    <NetworkList {...props} />
-    <NetworkView {...props} />
-  </Split>
-)
+const Ndex = props => {
+  const geneList = props.search.queryList
+
+  const sourceUUID = props.sourceUUID
+
+  const id = props.search.results.jobId
+
+  const checkCytoscapeConnection = props => {
+    cyRESTApi
+      .status(props.cyrest.port)
+      .catch(e => {
+        throw Error(e)
+      })
+      .then(res => handleErrors(res))
+      .then(running => {
+        props.cyrestActions.setAvailable(true)
+      })
+      .catch(error => {
+        props.cyrestActions.setAvailable(false)
+      })
+  }
+
+  const handleErrors = res => {
+    console.log('Calling!!', res)
+    if (res !== undefined) {
+      return true
+    }
+    return false
+  }
+
+  const handleFetch = (networkUUID, networkName, nodeCount, edgeCount) => {
+    props.networkActions.setNetworkSize({
+      nodeCount,
+      edgeCount
+    })
+
+    const networkSize = nodeCount + edgeCount
+
+    // Do not load if size is too big to render!
+    if (networkSize > NETWORK_SIZE_TH) {
+      return
+    }
+
+    checkCytoscapeConnection(props)
+    props.networkActions.networkFetchStarted({
+      id,
+      sourceUUID,
+      networkUUID,
+      networkName,
+      geneList
+    })
+  }
+
+  const handleImportNetwork = () => {
+    props.cyrestActions.importNetworkStarted(props.network.originalCX)
+  }
+
+  const renderNetworkListItem = (networkEntry, classes) => {
+    const {
+      description,
+      networkUUID,
+      percentOverlap,
+      nodes,
+      edges,
+      imageURL
+    } = networkEntry
+
+    return (
+      <MenuItem
+        className={classes.menuItem}
+        alignItems="flex-start"
+        key={networkUUID}
+        onClick={val => handleFetch(networkUUID, description, nodes, edges)}
+      >
+        <ListItemAvatar>
+          <Avatar className={classes.networkAvatar} src={imageURL} />
+        </ListItemAvatar>
+        <ListItemText
+          className={classes.menuText}
+          primary={description}
+          secondary={
+            <React.Fragment>
+              <Typography
+                component="span"
+                className={classes.inline}
+                color="textPrimary"
+              >
+                {'Nodes: ' + nodes + ', Edges: ' + edges}
+              </Typography>
+            </React.Fragment>
+          }
+        />
+
+        <ListItemSecondaryAction className={classes.secondary}>
+          <div
+            style={{
+              background: 'teal',
+              color: 'white',
+              height: '1.5em',
+              width: percentOverlap * 3 + 'px'
+            }}
+          >
+            <Typography variant="body2" style={{ color: '#AAAAAA' }}>
+              {percentOverlap + '%'}
+            </Typography>
+          </div>
+        </ListItemSecondaryAction>
+      </MenuItem>
+    )
+  }
+
+  return (
+    <Split sizes={[50, 50]} gutterSize={7} className="ndex-base">
+      <NetworkList renderNetworkListItem={renderNetworkListItem} {...props} />
+      <NetworkView handleImportNetwork={handleImportNetwork} {...props} />
+    </Split>
+  )
+}
 
 export default Ndex

--- a/src/containers/MainContainer/index.jsx
+++ b/src/containers/MainContainer/index.jsx
@@ -17,7 +17,8 @@ function mapStateToProps(state) {
     search: state.search,
     uiState: state.uiState,
     network: state.network,
-    source: state.source
+    source: state.source,
+    cyrest: state.cyrest
   }
 }
 

--- a/src/containers/TopPageContainer/index.jsx
+++ b/src/containers/TopPageContainer/index.jsx
@@ -8,6 +8,7 @@ import * as searchActions from '../../actions/search'
 import * as uiStateActions from '../../actions/uiState'
 import * as networkActions from '../../actions/network'
 import * as sourceActions from '../../actions/source'
+import * as cyrestActions from '../../actions/cyrest'
 
 const TopPageContainer = props => <TopPage {...props} />
 
@@ -16,7 +17,8 @@ function mapStateToProps(state) {
     search: state.search,
     uiState: state.uiState,
     network: state.network,
-    source: state.source
+    source: state.source,
+    cyrest: state.cyrest
   }
 }
 
@@ -25,7 +27,8 @@ function mapDispatchToProps(dispatch) {
     searchActions: bindActionCreators(searchActions, dispatch),
     uiStateActions: bindActionCreators(uiStateActions, dispatch),
     networkActions: bindActionCreators(networkActions, dispatch),
-    sourceActions: bindActionCreators(sourceActions, dispatch)
+    sourceActions: bindActionCreators(sourceActions, dispatch),
+    cyrestActions: bindActionCreators(cyrestActions, dispatch),
   }
 }
 

--- a/src/reducers/cyrest.js
+++ b/src/reducers/cyrest.js
@@ -2,10 +2,14 @@ import { handleActions } from 'redux-actions'
 import {
   importNetworkFailed,
   importNetworkStarted,
-  importNetworkSucceeded
+  importNetworkSucceeded,
+  setAvailable,
+  setPort
 } from '../actions/cyrest'
 
 const defaultState = {
+  available: false,
+  port: 1234,
   error: null
 }
 
@@ -29,6 +33,14 @@ const source = handleActions(
         ...state,
         error: payload.error
       }
+    },
+    [setPort]: (state, payload) => {
+      console.log('CyREST port = ', payload.payload)
+      return { ...state, port: payload.payload }
+    },
+    [setAvailable]: (state, payload) => {
+      console.log('CyREST available = ', payload.payload)
+      return { ...state, available: payload.payload }
     }
   },
   defaultState

--- a/src/reducers/uiState.js
+++ b/src/reducers/uiState.js
@@ -1,17 +1,14 @@
 import { handleActions } from 'redux-actions'
 import {
   setSettingsOpen,
-  setCytoscapeStatus,
   setServicesListOpen,
   setHighlights
 } from '../actions/uiState'
 
 const DEF_STATE = {
-  isCytoscapeRunning: false,
   isSettingsOpen: false,
   servicesListOpen: false,
-  highlights: true,
-  urlParams: new URLSearchParams(window.location.search)
+  highlights: true
 }
 
 const uiState = handleActions(
@@ -19,10 +16,6 @@ const uiState = handleActions(
     [setSettingsOpen]: (state, payload) => {
       console.log('OPEN = ', payload.payload)
       return { ...state, isSettingsOpen: payload.payload }
-    },
-    [setCytoscapeStatus]: (state, payload) => {
-      console.log('Cytoscape is running = ', payload.payload)
-      return { ...state, isCytoscapeRunning: payload.payload }
     },
     [setServicesListOpen]: (state, payload) => {
       return { ...state, servicesListOpen: payload.payload }

--- a/src/reducers/uiState.js
+++ b/src/reducers/uiState.js
@@ -2,13 +2,15 @@ import { handleActions } from 'redux-actions'
 import {
   setSettingsOpen,
   setCytoscapeStatus,
-  setServicesListOpen
+  setServicesListOpen,
+  setHighlights
 } from '../actions/uiState'
 
 const DEF_STATE = {
   isCytoscapeRunning: false,
   isSettingsOpen: false,
   servicesListOpen: false,
+  highlights: true,
   urlParams: new URLSearchParams(window.location.search)
 }
 
@@ -24,6 +26,9 @@ const uiState = handleActions(
     },
     [setServicesListOpen]: (state, payload) => {
       return { ...state, servicesListOpen: payload.payload }
+    },
+    [setHighlights]: (state, payload) => {
+      return { ...state, highlights: payload.payload }
     }
   },
   DEF_STATE

--- a/src/sagas/cyRestSaga.js
+++ b/src/sagas/cyRestSaga.js
@@ -11,7 +11,7 @@ export default function* cyrestSaga() {
   yield takeLatest(IMPORT_NETWORK_STARTED, watchImportNetwork)
 }
 
-export const getUIState = state => state.uiState
+export const getCyRESTPort = state => state.cyrest.port
 
 /**
  * Calling CyREST network import
@@ -22,10 +22,7 @@ export const getUIState = state => state.uiState
 function* watchImportNetwork(action) {
   const originalCX = action.payload
   try {
-    const uiState = yield select(getUIState)
-    const cyrestport = uiState.urlParams.has('cyrestport')
-      ? uiState.urlParams.get('cyrestport')
-      : 1234
+    const cyrestport = yield select(getCyRESTPort)
 
     let addNumberVerification = true
 


### PR DESCRIPTION
This addresses some issues regarding component re-use. From the issue in the fork:

> The following components/reducers can be refactored to improve re-use:
> 
> NDEx Network list item rendering and network fetching can be passed as props, same as the hits are now. Additionally, the related OpenInButton can have the handleImportNetwork function passed as a prop, allowing for different means of opening the network (search portal passes CX, while CyNDEx-2 calls a different app-specific CyREST endpoint)
> 
> CyREST shouldn't be creating URLSearchParams via the window, it should be using history instead. It should eventually do this via polling in a saga, not in component code.